### PR TITLE
Extend microarchitectures.json: Add cflags/cxxflags/fflags.

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1174,6 +1174,22 @@
             "versions": "5:",
             "flags": "-mcpu=thunderx2t99"
           }
+        ],
+        "fj": [
+          {
+            "version": ":4.0.0",
+            "flags": "-Knolargepage",
+            "cflags": "-Nclang",
+            "cxxflags": "-Nclang",
+            "fflags": "-KGENERIC_CPU -KNOSVE"
+          },
+          {
+            "version": "4.1.0:",
+            "flags": "-Knolargepage",
+            "cflags": "-Nclang -mcpu=thunderx2t99",
+            "cxxflags": "-Nclang -mcpu=thunderx2t99",
+            "fflags": "-KGENERIC_CPU -KNOSVE"
+          }
         ]
       }
     },
@@ -1230,7 +1246,12 @@
             "versions": "5:",
             "flags": "-march=armv8.2-a+crc+crypto+fp16+sve"
           }
-        ]
+        ],
+        "fj": {
+          "version": ":",
+          "cflags": "-Nclang",
+          "cxxflags": "-Nclang"
+        }
       }
     },
     "arm": {

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -55,6 +55,15 @@
                         },
                         "flags": {
                           "type": "string"
+                        },
+                        "cflags": {
+                          "type": "string"
+                        },
+                        "cxxflags": {
+                          "type": "string"
+                        },
+                        "fflags": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -75,6 +84,15 @@
                             "type": "string"
                           },
                           "flags": {
+                            "type": "string"
+                          },
+                          "cflags": {
+                            "type": "string"
+                          },
+                          "cxxflags": {
+                            "type": "string"
+                          },
+                          "fflags": {
                             "type": "string"
                           }
                         },


### PR DESCRIPTION
@tgamblin 
Fujitsu compiler has different optimization flags for each languages, so I add schema for  flags for each languages.