### PR TITLE
Simplify types in microarchitecture's JSON file

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: JSON Validation
 
 on:
   push:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,29 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: 
+      - master
+  schedule:
+  - cron: "0 4 * * *"
+    
+jobs:
+  validation:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies (Common)
+      run: |
+        pip install jsonschema
+    - name: Validate JSON file
+      run: |
+        jsonschema -i cpu/microarchitectures.json cpu/microarchitectures_schema.json
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://github.com/archspec/archspec-json/workflows/JSON%20Validation/badge.svg)](https://github.com/archspec/archspec-json/actions)
+
 # Archspec-json
 
 The [archspec-json](https://github.com/archspec/archspec-json) repository is part of the

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1,24 +1,24 @@
 {
   "microarchitectures": {
     "x86": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": []
     },
     "i686": {
-      "from": "x86",
+      "from": ["x86"],
       "vendor": "GenuineIntel",
       "features": []
     },
     "pentium2": {
-      "from": "i686",
+      "from": ["i686"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx"
       ]
     },
     "pentium3": {
-      "from": "pentium2",
+      "from": ["pentium2"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -26,7 +26,7 @@
       ]
     },
     "pentium4": {
-      "from": "pentium3",
+      "from": ["pentium3"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -35,7 +35,7 @@
       ]
     },
     "prescott": {
-      "from": "pentium4",
+      "from": ["pentium4"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -45,7 +45,7 @@
       ]
     },
     "x86_64": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
@@ -83,7 +83,7 @@
       }
     },
     "nocona": {
-      "from": "x86_64",
+      "from": ["x86_64"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -114,7 +114,7 @@
       }
     },
     "core2": {
-      "from": "nocona",
+      "from": ["nocona"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -144,7 +144,7 @@
       }
     },
     "nehalem": {
-      "from": "core2",
+      "from": ["core2"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -183,7 +183,7 @@
       }
     },
     "westmere": {
-      "from": "nehalem",
+      "from": ["nehalem"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -219,7 +219,7 @@
       }
     },
     "sandybridge": {
-      "from": "westmere",
+      "from": ["westmere"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -265,7 +265,7 @@
       }
     },
     "ivybridge": {
-      "from": "sandybridge",
+      "from": ["sandybridge"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -313,7 +313,7 @@
       }
     },
     "haswell": {
-      "from": "ivybridge",
+      "from": ["ivybridge"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -366,7 +366,7 @@
       }
     },
     "broadwell": {
-      "from": "haswell",
+      "from": ["haswell"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -411,7 +411,7 @@
       }
     },
     "skylake": {
-      "from": "broadwell",
+      "from": ["broadwell"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -459,7 +459,7 @@
       }
     },
     "mic_knl": {
-      "from": "broadwell",
+      "from": ["broadwell"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -512,7 +512,7 @@
       }
     },
     "skylake_avx512": {
-      "from": "skylake",
+      "from": ["skylake"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -569,7 +569,7 @@
       }
     },
     "cannonlake": {
-      "from": "skylake",
+      "from": ["skylake"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -626,7 +626,7 @@
       }
     },
     "cascadelake": {
-      "from": "skylake_avx512",
+      "from": ["skylake_avx512"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -757,7 +757,7 @@
       }
     },
     "k10": {
-      "from": "x86_64",
+      "from": ["x86_64"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -794,7 +794,7 @@
       }
     },
     "bulldozer": {
-      "from": "x86_64",
+      "from": ["x86_64"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -837,7 +837,7 @@
       }
     },
     "piledriver": {
-      "from": "bulldozer",
+      "from": ["bulldozer"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -884,7 +884,7 @@
       }
     },
     "steamroller": {
-      "from": "piledriver",
+      "from": ["piledriver"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -932,7 +932,7 @@
       }
     },
     "excavator": {
-      "from": "steamroller",
+      "from": ["steamroller"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -984,7 +984,7 @@
       }
     },
     "zen": {
-      "from": "x86_64",
+      "from": ["x86_64"],
       "vendor": "AuthenticAMD",
       "features": [
         "bmi1",
@@ -1039,7 +1039,7 @@
       }
     },
     "zen2": {
-      "from": "zen",
+      "from": ["zen"],
       "vendor": "AuthenticAMD",
       "features": [
         "bmi1",
@@ -1095,7 +1095,7 @@
       }
     },
     "ppc64": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
@@ -1115,7 +1115,7 @@
       }
     },
     "power7": {
-      "from": "ppc64",
+      "from": ["ppc64"],
       "vendor": "IBM",
       "generation": 7,
       "features": [],
@@ -1135,7 +1135,7 @@
       }
     },
     "power8": {
-      "from": "power7",
+      "from": ["power7"],
       "vendor": "IBM",
       "generation": 8,
       "features": [],
@@ -1160,7 +1160,7 @@
       }
     },
     "power9": {
-      "from": "power8",
+      "from": ["power8"],
       "vendor": "IBM",
       "generation": 9,
       "features": [],
@@ -1180,7 +1180,7 @@
       }
     },
     "ppc64le": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
@@ -1200,7 +1200,7 @@
       }
     },
     "power8le": {
-      "from": "ppc64le",
+      "from": ["ppc64le"],
       "vendor": "IBM",
       "generation": 8,
       "features": [],
@@ -1229,7 +1229,7 @@
       }
     },
     "power9le": {
-      "from": "power8le",
+      "from": ["power8le"],
       "vendor": "IBM",
       "generation": 9,
       "features": [],
@@ -1252,7 +1252,7 @@
       }
     },
     "aarch64": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
@@ -1271,7 +1271,7 @@
       }
     },
     "thunderx2": {
-      "from": "aarch64",
+      "from": ["aarch64"],
       "vendor": "Cavium",
       "features": [
         "fp",
@@ -1318,7 +1318,7 @@
       }
     },
     "a64fx": {
-      "from": "aarch64",
+      "from": ["aarch64"],
       "vendor": "Fujitsu",
       "features": [
         "fp",
@@ -1374,7 +1374,7 @@
       }
     },
     "arm": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
@@ -1388,28 +1388,28 @@
       }
     },
     "ppc": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
       }
     },
     "ppcle": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
       }
     },
     "sparc": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {
       }
     },
     "sparc64": {
-      "from": null,
+      "from": [],
       "vendor": "generic",
       "features": [],
       "compilers": {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -73,11 +73,13 @@
             "flags": "-march={name} -mtune=generic"
           }
         ],
-        "intel": {
-          "versions": ":",
-          "name": "pentium4",
-          "flags": "-march={name} -mtune=generic"
-        }
+        "intel": [
+          {
+            "versions": ":",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
       }
     },
     "nocona": {
@@ -90,19 +92,25 @@
         "sse3"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.0.4:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "name": "pentium4",
-          "flags": "-march={name} -mtune=generic"
-        }
+        "gcc": [
+          {
+            "versions": "4.0.4:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
       }
     },
     "core2": {
@@ -115,18 +123,24 @@
         "ssse3"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.3.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "flags": "-march={name} -mtune={name}}"
-        }
+        "gcc": [
+          {
+            "versions": "4.3.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "flags": "-march={name} -mtune={name}}"
+          }
+        ]
       }
     },
     "nehalem": {
@@ -153,15 +167,19 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "name": "corei7",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "westmere": {
@@ -179,19 +197,25 @@
         "pclmulqdq"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "name": "corei7",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "4.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "sandybridge": {
@@ -221,10 +245,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:17.9.0",
@@ -267,10 +293,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:17.9.0",
@@ -318,10 +346,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:17.9.0",
@@ -360,18 +390,24 @@
         "adx"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "4.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "18.0:",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "4.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "skylake": {
@@ -402,18 +438,24 @@
         "xsaveopt"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "6.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "18.0:",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "6.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "mic_knl": {
@@ -446,21 +488,27 @@
         "avx512cd"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "5.1:",
-          "name": "knl",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "knl",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "18.0:",
-          "name": "knl",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "5.1:",
+            "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "18.0:",
+            "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "skylake_avx512": {
@@ -497,21 +545,27 @@
         "avx512cd"
       ],
       "compilers": {
-        "gcc": {
-          "name": "skylake-avx512",
-          "versions": "6.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "skylake-avx512",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "18.0:",
-          "name": "skylake-avx512",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "skylake-avx512",
+            "versions": "6.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "skylake-avx512",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "18.0:",
+            "name": "skylake-avx512",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "cannonlake": {
@@ -551,18 +605,24 @@
         "umip"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "8.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "18.0:",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "cascadelake": {
@@ -600,18 +660,24 @@
         "avx512_vnni"
       ],
       "compilers": {
-        "gcc": {
-          "versions": "9.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "8.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "19.0:",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "9.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "19.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "icelake": {
@@ -663,11 +729,13 @@
         "vaes"
       ],
       "compilers": {
-        "gcc": {
-          "name": "icelake-client",
-          "versions": "8.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
+        "gcc": [
+          {
+            "name": "icelake-client",
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "clang": [
           {
             "versions": "7.0:",
@@ -679,11 +747,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "intel": {
-          "versions": "18.0:",
-          "name": "icelake-client",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "intel": [
+          {
+            "versions": "18.0:",
+            "name": "icelake-client",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "k10": {
@@ -700,21 +770,27 @@
         "3dnowext"
       ],
       "compilers": {
-        "gcc": {
-          "name": "amdfam10",
-          "versions": "4.3:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "amdfam10",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "flags": "-msse2"
-        }
+        "gcc": [
+          {
+            "name": "amdfam10",
+            "versions": "4.3:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "amdfam10",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse2"
+          }
+        ]
       }
     },
     "bulldozer": {
@@ -737,21 +813,27 @@
         "sse4_2"
       ],
       "compilers": {
-        "gcc": {
-          "name": "bdver1",
-          "versions": "4.7:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "bdver1",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "flags": "-msse3"
-        }
+        "gcc": [
+          {
+            "name": "bdver1",
+            "versions": "4.7:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "bdver1",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
       }
     },
     "piledriver": {
@@ -778,21 +860,27 @@
         "tbm"
       ],
       "compilers": {
-        "gcc": {
-          "name": "bdver2",
-          "versions": "4.7:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "bdver2",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "flags": "-msse3"
-        }
+        "gcc": [
+          {
+            "name": "bdver2",
+            "versions": "4.7:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "bdver2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
       }
     },
     "steamroller": {
@@ -820,21 +908,27 @@
         "tbm"
       ],
       "compilers": {
-        "gcc": {
-          "name": "bdver3",
-          "versions": "4.8:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "bdver3",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "flags": "-msse4.2"
-        }
+        "gcc": [
+          {
+            "name": "bdver3",
+            "versions": "4.8:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "bdver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse4.2"
+          }
+        ]
       }
     },
     "excavator": {
@@ -865,22 +959,28 @@
         "tbm"
       ],
       "compilers": {
-        "gcc": {
-          "name": "bdver4",
-          "versions": "4.9:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "name": "bdver4",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "name": "core-avx2",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "bdver4",
+            "versions": "4.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "name": "bdver4",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "zen": {
@@ -914,22 +1014,28 @@
         "popcnt"
       ],
       "compilers": {
-        "gcc": {
-          "name": "znver1",
-          "versions": "6.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "4.0:",
-          "name": "znver1",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "name": "core-avx2",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "znver1",
+            "versions": "6.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "4.0:",
+            "name": "znver1",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "zen2": {
@@ -964,22 +1070,28 @@
         "clwb"
       ],
       "compilers": {
-        "gcc": {
-          "name": "znver2",
-          "versions": "9.0:",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "9.0:",
-          "name": "znver2",
-          "flags": "-march={name} -mtune={name}"
-        },
-        "intel": {
-          "versions": "16.0:",
-          "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          "name": "core-avx2",
-          "flags": "-march={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "znver2",
+            "versions": "9.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "9.0:",
+            "name": "znver2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "ppc64": {
@@ -987,15 +1099,19 @@
       "vendor": "generic",
       "features": [],
       "compilers": {
-        "gcc": {
-          "name": "powerpc64",
-          "versions": ":",
-          "flags": "-mcpu={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": ":",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "powerpc64",
+            "versions": ":",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": ":",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "power7": {
@@ -1004,14 +1120,18 @@
       "generation": 7,
       "features": [],
       "compilers": {
-        "gcc": {
-          "versions": "4.4:",
-          "flags": "-mcpu={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "4.4:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "power8": {
@@ -1031,10 +1151,12 @@
             "flags": "-mcpu={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "power9": {
@@ -1043,14 +1165,18 @@
       "generation": 9,
       "features": [],
       "compilers": {
-        "gcc": {
-          "versions": "6.0:",
-          "flags": "-mcpu={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "versions": "6.0:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "ppc64le": {
@@ -1058,15 +1184,19 @@
       "vendor": "generic",
       "features": [],
       "compilers": {
-        "gcc": {
-          "name": "powerpc64le",
-          "versions": "4.8:",
-          "flags": "-mcpu={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": ":",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "powerpc64le",
+            "versions": "4.8:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": ":",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "power8le": {
@@ -1088,12 +1218,14 @@
             "flags": "-mcpu={name} -mtune={name}"
           }
         ],
-        "clang": {
-          "versions": "3.9:",
-          "family": "ppc64le",
-          "name": "power8",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "clang": [
+          {
+            "versions": "3.9:",
+            "family": "ppc64le",
+            "name": "power8",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "power9le": {
@@ -1102,17 +1234,21 @@
       "generation": 9,
       "features": [],
       "compilers": {
-        "gcc": {
-          "name": "power9",
-          "versions": "6.0:",
-          "flags": "-mcpu={name} -mtune={name}"
-        },
-        "clang": {
-          "versions": "3.9:",
-          "family": "ppc64le",
-          "name": "power9",
-          "flags": "-mcpu={name} -mtune={name}"
-        }
+        "gcc": [
+          {
+            "name": "power9",
+            "versions": "6.0:",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "3.9:",
+            "family": "ppc64le",
+            "name": "power9",
+            "flags": "-mcpu={name} -mtune={name}"
+          }
+        ]
       }
     },
     "aarch64": {
@@ -1120,14 +1256,18 @@
       "vendor": "generic",
       "features": [],
       "compilers": {
-        "gcc": {
-          "versions": "4.8.0:",
-          "flags": "-march=armv8-a -mtune=generic"
-        },
-        "clang": {
-          "versions": ":",
-          "flags": "-march=armv8-a -mtune=generic"
-        }
+        "gcc": [
+          {
+            "versions": "4.8.0:",
+            "flags": "-march=armv8-a -mtune=generic"
+          }
+        ],
+        "clang": [
+          {
+            "versions": ":",
+            "flags": "-march=armv8-a -mtune=generic"
+          }
+        ]
       }
     },
     "thunderx2": {
@@ -1238,11 +1378,13 @@
       "vendor": "generic",
       "features": [],
       "compilers": {
-        "clang": {
-          "versions": ":",
-          "family": "arm",
-          "flags": "-march={family} -mcpu=generic"
-        }
+        "clang": [
+          {
+            "versions": ":",
+            "family": "arm",
+            "flags": "-march={family} -mcpu=generic"
+          }
+        ]
       }
     },
     "ppc": {

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -42,49 +42,26 @@
               "type": "object",
               "patternProperties": {
                 "([\\w]*)": {
-                  "anyOf": [
-                    {
-                      "$comment": "Single entry (Compiler didn't change options across versions)",
-                      "type": "object",
-                      "properties": {
-                        "versions": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "flags": {
-                          "type": "string"
-                        }
+                  "$comment": "Permit multiple entries since compilers change options across versions",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "versions": {
+                        "type": "string"
                       },
-                      "required": [
-                        "versions",
-                        "flags"
-                      ]
-                    },
-                    {
-                      "$comment": "Multiple entries (Compiler change options across versions)",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "versions": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "flags": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "versions",
-                          "flags"
-                        ]
+                      "name": {
+                        "type": "string"
+                      },
+                      "flags": {
+                        "type": "string"
                       }
-                    }
-                  ]
+                    },
+                    "required": [
+                      "versions",
+                      "flags"
+                    ]
+                  }
                 }
               }
             }

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -11,23 +11,11 @@
           "type": "object",
           "properties": {
             "from": {
-              "anyOf": [
-                {
-                  "$comment": "More than one parent",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "$comment": "Exactly one parent",
-                  "type": "string"
-                },
-                {
-                  "$comment": "No parent",
-                  "type": "null"
-                }
-              ]
+              "$comment": "More than one parent",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "vendor": {
               "type": "string"


### PR DESCRIPTION
fixes #1

When complete this PR will:

- [x] Add a CI check to verify the JSON file against the schema
- [x] Modify the "compilers" attribute to only accept arrays of objects
- [x] Modify the "from" attribute to only accept list of strings