### PR TITLE
Don't use version suffix to distinguish among compilers

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -61,12 +61,14 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
-        "clang": [
+        "apple-clang": [
           {
-            "versions": "0.0.0-apple:",
+            "versions": ":",
             "name": "x86-64",
             "flags": "-march={name}"
-          },
+          }
+        ],
+        "clang": [
           {
             "versions": ":",
             "name": "x86-64",


### PR DESCRIPTION
Instead of suffixing the version of Clang with "-apple" change the name of Apple compiler to "apple-clang"