### PR TITLE
Archspec now has its own release number

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,5 @@
-Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-Spack and Archspec Project Developers. See the top-level COPYRIGHT file 
-for details.
+Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+Archspec Project Developers. See the top-level COPYRIGHT file for details.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -14,4 +14,23 @@ Currently the repository contains the following JSON files:
 └── cpu
     ├── microarchitectures.json         # Contains information on CPU microarchitectures
     └── microarchitectures_schema.json  # Schema for the file above
-```
+ ```
+
+
+## License
+
+Archspec is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0). Users may choose either license, at their
+option.
+
+All new contributions must be made under both the MIT and Apache-2.0
+licenses.
+
+See [LICENSE-MIT](https://github.com/archspec/archspec-json/blob/master/LICENSE-MIT),
+[LICENSE-APACHE](https://github.com/archspec/archspec-json/blob/master/LICENSE-APACHE),
+[COPYRIGHT](https://github.com/archspec/archspec-json/blob/master/COPYRIGHT), and
+[NOTICE](https://github.com/archspec/archspec-json/blob/master/NOTICE) for details.
+
+SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+LLNL-CODE-811653


### PR DESCRIPTION
Archspec grew out of Spack, so we initially just labeled it that way, but it's really its own project. I put in a separate code release for Archspec, so now we don't have to mention Spack in all the code headers.

- [x] added the new release number, LLNL-CODE-811653, to `README.md`
- [x] added license info to `README.md`
- [X] changed copyright year to start of archspec