### PR TITLE
Add AWS Graviton2

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1375,6 +1375,47 @@
         ]
       }
     },
+    "graviton2": {
+      "from": ["aarch64"],
+      "vendor": "AWS",
+      "features": [
+          "fp",
+          "asimd",
+          "evtstrm",
+          "aes",
+          "pmull",
+          "sha1",
+          "sha2",
+          "crc32",
+          "atomics",
+          "fphp",
+          "asimdhp",
+          "cpuid",
+          "asimdrdm",
+          "lrcpc",
+          "dcpop",
+          "asimddp",
+          "ssbs"
+      ],
+      "compilers" : {
+          "gcc": [
+              {
+                  "versions": ":8.9",
+                  "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto -mtune=cortex-a72"
+              },
+              {
+                  "versions": "9.0:",
+                  "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto -mtune=neoverse-n1"
+              }
+          ],
+          "clang" : [
+              {
+                  "versions": ":",
+                  "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
+              }
+          ]
+      }
+    },
     "arm": {
       "from": [],
       "vendor": "generic",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1377,7 +1377,7 @@
     },
     "graviton2": {
       "from": ["aarch64"],
-      "vendor": "AWS",
+      "vendor": "ARM",
       "features": [
           "fp",
           "asimd",


### PR DESCRIPTION
This PR adds the AWS Graviton2 processors to archspec.