### PR TITLE
Added support for apple-clang (Intel uarchs)

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -106,6 +106,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -134,6 +140,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -175,6 +187,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -208,6 +226,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -250,6 +274,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -298,6 +328,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -354,6 +390,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:17.9.0",
@@ -404,6 +446,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "18.0:",
@@ -449,6 +497,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -501,6 +555,12 @@
           {
             "versions": "3.9:",
             "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -558,6 +618,12 @@
           {
             "versions": "3.9:",
             "name": "skylake-avx512",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -619,6 +685,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "18.0:",
@@ -671,6 +743,12 @@
         "clang": [
           {
             "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "11.0:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -746,6 +824,17 @@
           },
           {
             "versions": "6.0:6.9",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "10.0.1:",
+            "name": "icelake-client",
+            "flags": "-march={name} -mtune={name}"
+          },
+          {
+            "versions": "10.0.0:10.0.99",
             "flags": "-march={name} -mtune={name}"
           }
         ],


### PR DESCRIPTION
The support has been inserted combining:
1. The support for LLVM Clang already present
2. The version translation table present at https://en.wikipedia.org/wiki/Xcode