### PR TITLE
Added architecture flags for AOCC compiler

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -75,6 +75,13 @@
             "flags": "-march={name} -mtune=generic"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
         "intel": [
           {
             "versions": ":",
@@ -104,6 +111,12 @@
           {
             "versions": "3.9:",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "apple-clang": [
@@ -141,6 +154,12 @@
           {
             "versions": "3.9:",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "apple-clang": [
@@ -187,6 +206,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
         "apple-clang": [
           {
             "versions": "8.0:",
@@ -227,6 +252,12 @@
           {
             "versions": "3.9:",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "apple-clang": [
@@ -274,6 +305,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -328,6 +365,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -390,6 +433,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "apple-clang": [
           {
             "versions": "8.0:",
@@ -446,6 +495,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "apple-clang": [
           {
             "versions": "8.0:",
@@ -497,6 +552,12 @@
         "clang": [
           {
             "versions": "3.9:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -556,6 +617,13 @@
             "versions": "3.9:",
             "name": "knl",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+        "name": "knl",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "apple-clang": [
@@ -619,6 +687,13 @@
             "versions": "3.9:",
             "name": "skylake-avx512",
             "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+        "name": "skylake-avx512",
+            "flags": "-march={name} -mtune=generic"
           }
         ],
         "apple-clang": [
@@ -685,6 +760,12 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "apple-clang": [
           {
             "versions": "8.0:",
@@ -743,6 +824,12 @@
         "clang": [
           {
             "versions": "8.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "flags": "-march={name} -mtune={name}"
           }
         ],
@@ -827,6 +914,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+        "name": "icelake-client",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "apple-clang": [
           {
             "versions": "10.0.1:",
@@ -875,6 +969,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "name": "amdfam10",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -914,6 +1015,13 @@
         "clang": [
           {
             "versions": "3.9:",
+            "name": "bdver1",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "name": "bdver1",
             "flags": "-march={name} -mtune={name}"
           }
@@ -961,6 +1069,13 @@
         "clang": [
           {
             "versions": "3.9:",
+            "name": "bdver2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "name": "bdver2",
             "flags": "-march={name} -mtune={name}"
           }
@@ -1013,6 +1128,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "name": "bdver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -1060,6 +1182,13 @@
         "clang": [
           {
             "versions": "3.9:",
+            "name": "bdver4",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "name": "bdver4",
             "flags": "-march={name} -mtune={name}"
           }
@@ -1119,6 +1248,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "aocc": [
+          {
+            "versions": "2.2:",
+            "name": "znver1",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -1171,6 +1307,13 @@
         "clang": [
           {
             "versions": "9.0:",
+            "name": "znver2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "aocc": [
+          {
+            "versions": "2.2:",
             "name": "znver2",
             "flags": "-march={name} -mtune={name}"
           }

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -622,7 +622,7 @@
         "aocc": [
           {
             "versions": "2.2:",
-        "name": "knl",
+            "name": "knl",
             "flags": "-march={name} -mtune=generic"
           }
         ],
@@ -692,7 +692,7 @@
         "aocc": [
           {
             "versions": "2.2:",
-        "name": "skylake-avx512",
+            "name": "skylake-avx512",
             "flags": "-march={name} -mtune=generic"
           }
         ],
@@ -917,7 +917,7 @@
         "aocc": [
           {
             "versions": "2.2:",
-        "name": "icelake-client",
+            "name": "icelake-client",
             "flags": "-march={name} -mtune={name}"
           }
         ],


### PR DESCRIPTION
Architecture flags have been added for the AOCC compiler in file microarchitectures.json given below

File:
archspec-json/cpu/microarchitectures.json