### PR TITLE
Fix version range for cascadelake/intel

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -841,7 +841,7 @@
         ],
         "intel": [
           {
-            "versions": "19.0:",
+            "versions": "19.0.1:",
             "flags": "-march={name} -mtune={name}"
           }
         ]


### PR DESCRIPTION
Discovered by a Spack user using intel@19.0.0. The 19.0.0 compiler does not support cascadelake, the 19.0.1 compiler does.

See https://software.intel.com/content/www/us/en/develop/articles/intel-c-compiler-190-for-linux-release-notes-for-intel-parallel-studio-xe-2019.html#history