### PR TITLE
Add tentative entry for Apple M1

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1501,6 +1501,12 @@
             "versions": ":",
             "flags": "-march=armv8-a -mtune=generic"
           }
+        ],
+        "apple-clang": [
+          {
+            "versions": ":",
+            "flags": "-march=armv8-a -mtune=generic"
+          }
         ]
       }
     },
@@ -1707,6 +1713,31 @@
                   "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
               }
           ]
+      }
+    },
+    "m1": {
+      "from": ["aarch64"],
+      "vendor": "Apple",
+      "features": [],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "8.0:",
+            "flags" : "-march=armv8.4-a -mtune=generic"
+          }
+        ],
+        "clang" : [
+          {
+            "versions": "9.0:",
+            "flags" : "-march=armv8.4-a"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "11.0:",
+            "flags" : "-march=armv8.4-a"
+          }
+        ]
       }
     },
     "arm": {

--- a/tests/targets/darwin-bigsur-m1
+++ b/tests/targets/darwin-bigsur-m1
@@ -1,0 +1,19 @@
+machdep.cpu.cores_per_package: 8
+machdep.cpu.core_count: 8
+machdep.cpu.logical_per_package: 8
+machdep.cpu.thread_count: 8
+machdep.cpu.brand_string: Apple processor
+hw.optional.floatingpoint: 1
+hw.optional.watchpoint: 4
+hw.optional.breakpoint: 6
+hw.optional.neon: 1
+hw.optional.neon_hpfp: 1
+hw.optional.neon_fp16: 1
+hw.optional.armv8_1_atomics: 1
+hw.optional.armv8_crc32: 1
+hw.optional.armv8_2_fhm: 1
+hw.optional.armv8_2_sha512: 1
+hw.optional.armv8_2_sha3: 1
+hw.optional.amx_version: 2
+hw.optional.ucnormal_mem: 1
+hw.optional.arm64: 1


### PR DESCRIPTION
refers to https://github.com/archspec/archspec/issues/38

This PR adds an entry for Apple M1. Currently I don't have a CPU to test on, so I'm coding this based on reported output from `sysctl`. It seems we don't have much information from Apple, in particular concerning CPU features. I think that all the features listed as `hw.optional` should be added to the JSON file but I still need to double check if this is consistent with the semantics of other `aarch64` architectures. 

Also, the compiler flags are generic for armv8.4-a and not tested on any actual application. It would be good if reviewers could comment on that.