### PR TITLE
Removed 'erms' from microarchitectures.json for znver3

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1358,7 +1358,6 @@
         "clflushopt",
         "popcnt",
         "clwb",
-        "erms",
         "invpcid",
         "ospke",
         "pku",


### PR DESCRIPTION
Removed 'erms' from microarchitectures.json for znver3