### PR TITLE
Removed entries invpcid,ospke, pku, in  znver3 section

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1358,9 +1358,6 @@
         "clflushopt",
         "popcnt",
         "clwb",
-        "invpcid",
-        "ospke",
-        "pku",
         "vaes",
         "vpclmulqdq"
       ],


### PR DESCRIPTION
Removed entries invpcid,ospke, pku, in  znver3 section as they are not required for detection of znver3