### PR TITLE
zen3: added pku feature, GCC and Clang support

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1370,6 +1370,13 @@
             "flags": "-march={name} -mtune={name}"
           }
         ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "znver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "aocc": [
           {
             "versions": "3.0:",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1359,9 +1359,17 @@
         "popcnt",
         "clwb",
         "vaes",
-        "vpclmulqdq"
+        "vpclmulqdq",
+        "pku"
       ],
       "compilers": {
+        "gcc": [
+          {
+            "versions": "11.0:",
+            "name": "znver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "aocc": [
           {
             "versions": "3.0:",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1365,7 +1365,7 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "11.0:",
+            "versions": "10.3:",
             "name": "znver3",
             "flags": "-march={name} -mtune={name}"
           }


### PR DESCRIPTION
I just compiled the development version of GCC and:
```
znver3
        AMD Family 19h core based CPUs with x86-64 instruction set support. (This supersets BMI, BMI2, CLWB, F16C, FMA, FSGSBASE, AVX, AVX2, ADCX, RDSEED, MWAITX, SHA, CLZERO, AES, PCLMUL,
        CX16, MOVBE, MMX, SSE, SSE2, SSE3, SSE4A, SSSE3, SSE4.1, SSE4.2, ABM, XSAVEC, XSAVES, CLFLUSHOPT, POPCNT, RDPID, WBNOINVD, PKU, VPCLMULQDQ, VAES, and 64-bit instruction set
        extensions.)
```
It seems that zen3 has PKU, VPCLMULQDQ, VAES more with respect to zen2, so adding the missing one and support for GCC