### PR TITLE
Add support for microarchitecture levels

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1146,7 +1146,7 @@
       }
     },
     "bulldozer": {
-      "from": ["x86_64", "x86_64_v2"],
+      "from": ["x86_64_v2"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -1364,7 +1364,7 @@
       }
     },
     "zen": {
-      "from": ["x86_64"],
+      "from": ["x86_64_v3"],
       "vendor": "AuthenticAMD",
       "features": [
         "bmi1",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -91,6 +91,166 @@
         ]
       }
     },
+    "x86_64_v2": {
+      "from": ["x86_64"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.6:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ]
+      }
+    },
+    "x86_64_v3": {
+      "from": ["x86_64_v2"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.8:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ]
+      }
+    },
+    "x86_64_v4": {
+      "from": ["x86_64_v3"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave",
+        "avx512f",
+        "avx512bw",
+        "avx512cd",
+        "avx512dq",
+        "avx512vl"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "6.0:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ]
+      }
+    },
     "nocona": {
       "from": ["x86_64"],
       "vendor": "GenuineIntel",
@@ -172,47 +332,6 @@
           {
             "versions": "16.0:",
             "flags": "-march={name} -mtune={name}"
-          }
-        ]
-      }
-    },
-    "x86_64_v2": {
-      "from": ["x86_64"],
-      "vendor": "generic",
-      "features": [
-        "cx16",
-        "lahf_lm",
-        "mmx",
-        "sse",
-        "sse2",
-        "ssse3",
-        "sse4_1",
-        "sse4_2",
-        "popcnt"
-      ],
-      "compilers": {
-        "gcc": [
-          {
-            "versions": "11.1:",
-            "name": "x86-64-v2",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "4.6:11.0",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
-          }
-        ],
-        "clang": [
-          {
-            "versions": "12.0:",
-            "name": "x86-64-v2",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "3.9:11.1",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
           }
         ]
       }
@@ -430,63 +549,6 @@
           {
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
-          }
-        ]
-      }
-    },
-    "x86_64_v3": {
-      "from": ["x86_64_v2"],
-      "vendor": "generic",
-      "features": [
-        "cx16",
-        "lahf_lm",
-        "mmx",
-        "sse",
-        "sse2",
-        "ssse3",
-        "sse4_1",
-        "sse4_2",
-        "popcnt",
-        "avx",
-        "avx2",
-        "bmi1",
-        "bmi2",
-        "f16c",
-        "fma",
-        "abm",
-        "movbe",
-        "xsave"
-      ],
-      "compilers": {
-        "gcc": [
-          {
-            "versions": "11.1:",
-            "name": "x86-64-v3",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "4.8:11.0",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
-          }
-        ],
-        "clang": [
-          {
-            "versions": "12.0:",
-            "name": "x86-64-v3",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "3.9:11.1",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
-          }
-        ],
-        "apple-clang": [
-          {
-            "versions": "8.0:",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
           }
         ]
       }
@@ -735,68 +797,6 @@
             "versions": "18.0:",
             "name": "knl",
             "flags": "-march={name} -mtune={name}"
-          }
-        ]
-      }
-    },
-    "x86_64_v4": {
-      "from": ["x86_64_v3"],
-      "vendor": "generic",
-      "features": [
-        "cx16",
-        "lahf_lm",
-        "mmx",
-        "sse",
-        "sse2",
-        "ssse3",
-        "sse4_1",
-        "sse4_2",
-        "popcnt",
-        "avx",
-        "avx2",
-        "bmi1",
-        "bmi2",
-        "f16c",
-        "fma",
-        "abm",
-        "movbe",
-        "xsave",
-        "avx512f",
-        "avx512bw",
-        "avx512cd",
-        "avx512dq",
-        "avx512vl"
-      ],
-      "compilers": {
-        "gcc": [
-          {
-            "versions": "11.1:",
-            "name": "x86-64-v4",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "6.0:11.0",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
-          }
-        ],
-        "clang": [
-          {
-            "versions": "12.0:",
-            "name": "x86-64-v4",
-            "flags": "-march={name} -mtune=generic"
-          },
-          {
-            "versions": "3.9:11.1",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
-          }
-        ],
-        "apple-clang": [
-          {
-            "versions": "8.0:",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
           }
         ]
       }

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -196,7 +196,7 @@
             "flags": "-march={name} -mtune=generic"
           },
           {
-            "versions": "4.6:10.3",
+            "versions": "4.6:11.0",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
           }
@@ -462,7 +462,7 @@
             "flags": "-march={name} -mtune=generic"
           },
           {
-            "versions": "4.8:10.3",
+            "versions": "4.8:11.0",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
           }
@@ -777,7 +777,7 @@
             "flags": "-march={name} -mtune=generic"
           },
           {
-            "versions": "6.0:10.3",
+            "versions": "6.0:11.0",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
           }

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -177,9 +177,11 @@
       }
     },
     "x86_64_v2": {
-      "from": ["core2"],
+      "from": ["x86_64"],
       "vendor": "generic",
       "features": [
+        "cx16",
+        "lahf_lm",
         "mmx",
         "sse",
         "sse2",
@@ -216,7 +218,7 @@
       }
     },
     "nehalem": {
-      "from": ["x86_64_v2"],
+      "from": ["core2", "x86_64_v2"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -433,9 +435,11 @@
       }
     },
     "x86_64_v3": {
-      "from": ["ivybridge"],
+      "from": ["x86_64_v2"],
       "vendor": "generic",
       "features": [
+        "cx16",
+        "lahf_lm",
         "mmx",
         "sse",
         "sse2",
@@ -443,16 +447,15 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
-        "aes",
-        "pclmulqdq",
         "avx",
-        "rdrand",
-        "f16c",
-        "movbe",
-        "fma",
         "avx2",
         "bmi1",
-        "bmi2"
+        "bmi2",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave"
       ],
       "compilers": {
         "gcc": [
@@ -489,7 +492,7 @@
       }
     },
     "haswell": {
-      "from": ["x86_64_v3"],
+      "from": ["ivybridge", "x86_64_v3"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -737,9 +740,11 @@
       }
     },
     "x86_64_v4": {
-      "from": ["skylake"],
+      "from": ["x86_64_v3"],
       "vendor": "generic",
       "features": [
+        "cx16",
+        "lahf_lm",
         "mmx",
         "sse",
         "sse2",
@@ -747,27 +752,20 @@
         "sse4_1",
         "sse4_2",
         "popcnt",
-        "aes",
-        "pclmulqdq",
         "avx",
-        "rdrand",
-        "f16c",
-        "movbe",
-        "fma",
         "avx2",
         "bmi1",
         "bmi2",
-        "rdseed",
-        "adx",
-        "clflushopt",
-        "xsavec",
-        "xsaveopt",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave",
         "avx512f",
-        "clwb",
-        "avx512vl",
         "avx512bw",
+        "avx512cd",
         "avx512dq",
-        "avx512cd"
+        "avx512vl"
       ],
       "compilers": {
         "gcc": [
@@ -804,7 +802,7 @@
       }
     },
     "skylake_avx512": {
-      "from": ["x86_64_v4"],
+      "from": ["skylake", "x86_64_v4"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -1148,7 +1146,7 @@
       }
     },
     "bulldozer": {
-      "from": ["x86_64"],
+      "from": ["x86_64", "x86_64_v2"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -1307,7 +1305,7 @@
       }
     },
     "excavator": {
-      "from": ["steamroller"],
+      "from": ["steamroller", "x86_64_v3"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -176,8 +176,47 @@
         ]
       }
     },
-    "nehalem": {
+    "x86_64_v2": {
       "from": ["core2"],
+      "vendor": "generic",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.6:10.3",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ]
+      }
+    },
+    "nehalem": {
+      "from": ["x86_64_v2"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -393,8 +432,64 @@
         ]
       }
     },
-    "haswell": {
+    "x86_64_v3": {
       "from": ["ivybridge"],
+      "vendor": "generic",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "aes",
+        "pclmulqdq",
+        "avx",
+        "rdrand",
+        "f16c",
+        "movbe",
+        "fma",
+        "avx2",
+        "bmi1",
+        "bmi2"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.8:10.3",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ]
+      }
+    },
+    "haswell": {
+      "from": ["x86_64_v3"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -641,8 +736,75 @@
         ]
       }
     },
-    "skylake_avx512": {
+    "x86_64_v4": {
       "from": ["skylake"],
+      "vendor": "generic",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "aes",
+        "pclmulqdq",
+        "avx",
+        "rdrand",
+        "f16c",
+        "movbe",
+        "fma",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "rdseed",
+        "adx",
+        "clflushopt",
+        "xsavec",
+        "xsaveopt",
+        "avx512f",
+        "clwb",
+        "avx512vl",
+        "avx512bw",
+        "avx512dq",
+        "avx512cd"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "6.0:10.3",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ]
+      }
+    },
+    "skylake_avx512": {
+      "from": ["x86_64_v4"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",


### PR DESCRIPTION
This introduces definitions for the [microarchitecture levels](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels):
- `x86-64-v2` (basically an alias to `nehalem` with generic tuning)
- `x86-64-v3` (alias to `haswell` with generic tuning)
- `x86-64-v4` (alias to `skylake_avx512` with generic tuning)

I also implemented equivalent compiler flags for gcc < 11.1 and clang < 12.0.

It's my first PR pm archspec, so I have some doubts about how to tune the compiler version ranges and the features list.

Resolves archspec/archspec-json#30