### PR TITLE
add arm compiler support to graviton2

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1942,7 +1942,14 @@
                   "versions": "5:",
                   "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
               }
+          ],
+          "arm" : [
+              {
+                  "versions": "20:",
+                  "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
+              }
           ]
+          
       }
     },
     "m1": {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1949,7 +1949,6 @@
                   "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
               }
           ]
-          
       }
     },
     "m1": {


### PR DESCRIPTION
When we use arm compiler to compile applications on amazon graviton2 machines, there is a warning that arm compiler cannot build optimized binaries for "graviton2" and turns it to aarch64. Thus, I add this arm section to gravition2. It has passed our testing.