### PR TITLE
Add riscv64 arch and u74mc uarch

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2017,6 +2017,32 @@
       "features": [],
       "compilers": {
       }
+    },
+    "riscv64": {
+      "from": [],
+      "vendor": "generic",
+      "features": [],
+      "compilers": {
+      }
+    },
+    "u74mc": {
+      "from": ["riscv64"],
+      "vendor": "SiFive",
+      "features": [],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "10.2:",
+            "flags" : "-mtune=sifive-7-series"
+          }
+        ],
+        "clang" : [
+          {
+            "versions": "12.0:",
+            "flags" : "-mtune=sifive-7-series"
+          }
+        ]
+      }
     }
   },
   "feature_aliases": {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2023,6 +2023,18 @@
       "vendor": "generic",
       "features": [],
       "compilers": {
+        "gcc": [
+          {
+            "versions": "7.1:",
+            "flags" : "-march=rv64gc"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "9.0:",
+            "flags" : "-march=rv64gc"
+          }
+        ]
       }
     },
     "u74mc": {
@@ -2033,13 +2045,13 @@
         "gcc": [
           {
             "versions": "10.2:",
-            "flags" : "-mtune=sifive-7-series"
+            "flags" : "-march=rv64gc -mtune=sifive-7-series"
           }
         ],
         "clang" : [
           {
             "versions": "12.0:",
-            "flags" : "-mtune=sifive-7-series"
+            "flags" : "-march=rv64gc -mtune=sifive-7-series"
           }
         ]
       }

--- a/tests/targets/linux-sifive-u74mc
+++ b/tests/targets/linux-sifive-u74mc
@@ -1,0 +1,5 @@
+processor       : 0
+hart            : 4
+isa             : rv64imafdc
+mmu             : sv39
+uarch           : sifive,u74-mc


### PR DESCRIPTION
Add riscv64 arch and u74mc uarch, both of which are needed to support the SiFive Unmatched board.