### PR TITLE
Add Clang optimization flags for Apple M1

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1964,14 +1964,22 @@
         ],
         "clang" : [
           {
-            "versions": "9.0:",
+            "versions": "9.0:12.0",
             "flags" : "-march=armv8.4-a"
+          },
+          {
+            "versions": "13.0:",
+            "flags" : "-march=armv8.5-a+aes+sha2+sha3+fp16fml+fp16+rcpc+dotprod -mcpu=apple-m1"
           }
         ],
         "apple-clang": [
           {
-            "versions": "11.0:",
+            "versions": "11.0:12.5",
             "flags" : "-march=armv8.4-a"
+          },
+          {
+            "versions": "13.0:",
+            "flags" : "-march=armv8.5-a+aes+sha2+sha3+fp16fml+fp16+rcpc+dotprod -mcpu=apple-m1"
           }
         ]
       }

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1969,7 +1969,7 @@
           },
           {
             "versions": "13.0:",
-            "flags" : "-march=armv8.5-a+aes+sha2+sha3+fp16fml+fp16+rcpc+dotprod -mcpu=apple-m1"
+            "flags" : "-mcpu=apple-m1"
           }
         ],
         "apple-clang": [
@@ -1979,7 +1979,7 @@
           },
           {
             "versions": "13.0:",
-            "flags" : "-march=armv8.5-a+aes+sha2+sha3+fp16fml+fp16+rcpc+dotprod -mcpu=apple-m1"
+            "flags" : "-mcpu=apple-m1"
           }
         ]
       }


### PR DESCRIPTION
Vanilla Clang supports tuning for `apple-m1` target since version 13: https://github.com/llvm/llvm-project/commit/a8a3a43792472c9775c60fa79b9357033d47ce40.  Also Apple Clang 13 supports the `apple-m1` target.

I think this may fix #42.  CC: @trws

Side note: I'm not touching GCC, but I'm not sure it makes much sense, especially starting from version 8, since no stable version of GCC can target that platform.  https://github.com/iains/gcc-darwin-arm64 is the only fork of GCC I know which can compile for this platform, at https://github.com/iains/gcc-darwin-arm64/issues/86#issuecomment-1089406128 there is a possible value of `-march` (but at the moment it doesn't do any further optimisation, no support for specific `-mcpu`).