### PR TITLE
Improve a64fx microarchitecture

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1825,7 +1825,7 @@
           },
           {
             "versions": "10.3:",
-            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve -mcpu=a64fx -msve-vector-bits=512"
+            "flags": "-mcpu=a64fx -msve-vector-bits=512"
           }
         ],
         "clang": [
@@ -1839,7 +1839,7 @@
           },
           {
             "versions": "11:",
-            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve -mcpu=a64fx"
+            "flags": "-mcpu=a64fx"
           }
         ],
         "arm": [

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1788,7 +1788,6 @@
         "fp",
         "asimd",
         "evtstrm",
-        "aes",
         "pmull",
         "sha1",
         "sha2",
@@ -1821,18 +1820,26 @@
             "flags": "-march=armv8.2-a+crc+crypto+fp16"
           },
           {
-            "versions": "8:",
-            "flags": "-march=armv8.2-a+crc+aes+sha2+fp16+sve -msve-vector-bits=512"
+            "versions": "8:10.2",
+            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve -msve-vector-bits=512"
+          },
+          {
+            "versions": "10.3:",
+            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve -mcpu=a64fx -msve-vector-bits=512"
           }
         ],
         "clang": [
           {
             "versions": "3.9:4.9",
-            "flags": "-march=armv8.2-a+crc+crypto+fp16"
+            "flags": "-march=armv8.2-a+crc+sha2+fp16"
           },
           {
-            "versions": "5:",
-            "flags": "-march=armv8.2-a+crc+crypto+fp16+sve"
+            "versions": "5:10",
+            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve"
+          },
+          {
+            "versions": "11:",
+            "flags": "-march=armv8.2-a+crc+sha2+fp16+sve -mcpu=a64fx"
           }
         ],
         "arm": [


### PR DESCRIPTION
* Remove AES feature, apparently not supported in all CPU models.  Also LLVM
  doesn't use this feature on this CPU
* `-mpcu=a64fx` is supported in GCC since version 10.3:
  <https://www.gnu.org/software/gcc/gcc-10/changes.html>
* `-mcpu=a64fx` is supported in LLVM since version 11:
  <https://github.com/llvm/llvm-project/commit/c8cd1a994d28e5e822bd0d3c9a6b0aae2abb510f>

Fix #23.