### PR TITLE
Add oneapi compiler

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -95,7 +95,7 @@
             "name": "pentium4",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -312,7 +312,7 @@
             "name": "pentium4",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -367,7 +367,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -431,7 +431,7 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -493,7 +493,7 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -564,7 +564,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -636,7 +636,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -713,7 +713,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -782,7 +782,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -854,7 +854,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -933,7 +933,7 @@
             "name": "knl",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1017,7 +1017,7 @@
             "name": "skylake-avx512",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1099,7 +1099,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1178,7 +1178,7 @@
             "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1285,7 +1285,7 @@
             "name": "icelake-client",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1343,7 +1343,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse2"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1407,7 +1407,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1475,7 +1475,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1544,7 +1544,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse4.2"
           }
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1618,7 +1618,7 @@
           }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1696,7 +1696,7 @@
           }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1775,7 +1775,7 @@
           }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",
@@ -1857,7 +1857,7 @@
           }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
-        ]
+        ],
         "dpcpp": [
           {
             "versions": ":",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1615,9 +1615,9 @@
           {
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
         ],
         "dpcpp": [
           {
@@ -1693,9 +1693,9 @@
           {
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
         ],
         "dpcpp": [
           {
@@ -1772,9 +1772,9 @@
           {
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
         ],
         "dpcpp": [
           {
@@ -1841,7 +1841,7 @@
             "name": "znver3",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "intel": [
           {
             "versions": "16.0:",
@@ -1854,9 +1854,9 @@
           {
             "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
-          }
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
+          }
         ],
         "dpcpp": [
           {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -88,7 +88,7 @@
             "name": "pentium4",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -305,7 +305,7 @@
             "name": "pentium4",
             "flags": "-march={name} -mtune=generic"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -361,7 +361,7 @@
             "versions": "16.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -424,7 +424,7 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -486,7 +486,7 @@
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -558,7 +558,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -630,7 +630,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -707,7 +707,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -776,7 +776,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -848,7 +848,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -926,7 +926,7 @@
             "name": "knl",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1010,7 +1010,7 @@
             "name": "skylake-avx512",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1093,7 +1093,7 @@
             "versions": "18.0:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1172,7 +1172,7 @@
             "versions": "19.0.1:",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1278,7 +1278,7 @@
             "name": "icelake-client",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1336,7 +1336,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse2"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1400,7 +1400,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1468,7 +1468,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1537,7 +1537,7 @@
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse4.2"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1610,7 +1610,7 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1688,7 +1688,7 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1767,7 +1767,7 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",
@@ -1849,7 +1849,7 @@
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
-        ]
+        ],
         "oneapi": [
           {
             "versions": ":",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -89,6 +89,20 @@
             "flags": "-march={name} -mtune=generic"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
       }
     },
     "x86_64_v2": {
@@ -292,6 +306,20 @@
             "flags": "-march={name} -mtune=generic"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "pentium4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ]
       }
     },
     "core2": {
@@ -331,6 +359,18 @@
         "intel": [
           {
             "versions": "16.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
         ]
@@ -385,6 +425,20 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "westmere": {
@@ -429,6 +483,20 @@
         "intel": [
           {
             "versions": "16.0:",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "corei7",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "name": "corei7",
             "flags": "-march={name} -mtune={name}"
           }
@@ -491,6 +559,18 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "ivybridge": {
@@ -548,6 +628,18 @@
           },
           {
             "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
         ]
@@ -616,6 +708,18 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "broadwell": {
@@ -670,6 +774,18 @@
         "intel": [
           {
             "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
         ]
@@ -730,6 +846,18 @@
         "intel": [
           {
             "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
         ]
@@ -795,6 +923,20 @@
         "intel": [
           {
             "versions": "18.0:",
+            "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "knl",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "name": "knl",
             "flags": "-march={name} -mtune={name}"
           }
@@ -869,6 +1011,20 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "skylake-avx512",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "skylake-avx512",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "cannonlake": {
@@ -938,6 +1094,18 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "cascadelake": {
@@ -1002,6 +1170,18 @@
         "intel": [
           {
             "versions": "19.0.1:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "flags": "-march={name} -mtune={name}"
           }
         ]
@@ -1099,6 +1279,20 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "icelake-client",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "icelake-client",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "k10": {
@@ -1139,6 +1333,20 @@
         "intel": [
           {
             "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse2"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse2"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse2"
           }
@@ -1189,6 +1397,20 @@
         "intel": [
           {
             "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse3"
           }
@@ -1247,6 +1469,20 @@
             "flags": "-msse3"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse3"
+          }
+        ]
       }
     },
     "steamroller": {
@@ -1298,6 +1534,20 @@
         "intel": [
           {
             "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse4.2"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "flags": "-msse4.2"
+          }
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "flags": "-msse4.2"
           }
@@ -1361,6 +1611,22 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+          }
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "zen": {
@@ -1418,6 +1684,22 @@
         "intel": [
           {
             "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+          }
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
             "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
             "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
@@ -1486,6 +1768,22 @@
             "flags": "-march={name} -mtune={name}"
           }
         ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+          }
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
       }
     },
     "zen3": {
@@ -1541,6 +1839,30 @@
           {
             "versions": "3.0:",
             "name": "znver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "intel": [
+          {
+            "versions": "16.0:",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+        "oneapi": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+          }
+            "name": "core-avx2",
+            "flags": "-march={name} -mtune={name}"
+        ]
+        "dpcpp": [
+          {
+            "versions": ":",
+            "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+            "name": "core-avx2",
             "flags": "-march={name} -mtune={name}"
           }
         ]


### PR DESCRIPTION
This PR adds the oneapi and dpcpp compilers to archspec. These compilers
are Intel's latest generation compilers and have similar options to the
classic Intel compilers. As such, the entries here are based on the
intel entires.

Note: I also added entries, including for intel, to the zen3 block. If
there was a reason that the intel compiler was not there then the new
entries in that section will need to be removed.