### PR TITLE
OneAPI support for x86-64-v[2-4] in 2021.2.0:

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -146,14 +146,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v2",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v2",
             "flags": "-march={name} -mtune=generic"
           }
@@ -217,14 +217,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v3",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v3",
             "flags": "-march={name} -mtune=generic"
           }
@@ -293,14 +293,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v4",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v4",
             "flags": "-march={name} -mtune=generic"
           }


### PR DESCRIPTION
Version 2021.2.0 introduced support for x86-64-v2, x86-64-v3, and x86-64-v4 arch flags.