### PR TITLE
add graviton3 as known CPU microarchitecture

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2319,6 +2319,36 @@
           ]
       }
     },
+    "graviton3": {
+      "from": ["aarch64"],
+      "vendor": "ARM",
+      "features": [
+          "fp",
+          "asimd",
+          "evtstrm",
+          "aes",
+          "pmull",
+          "sha1",
+          "sha2",
+          "crc32",
+          "atomics",
+          "fphp",
+          "asimdhp",
+          "cpuid",
+          "asimdrdm",
+          "fcma",
+          "lrcpc",
+          "dcpop",
+          "sha3",
+          "asimddp",
+          "ssbs",
+          "sha512",
+          "sve",
+          "asimdfhm",
+          "flagm",
+          "ssbs"
+      ]
+    },
     "m1": {
       "from": ["aarch64"],
       "vendor": "Apple",

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Schema for microarchitecture definitions and feature aliases",
+  "title": "Schema for CPU microarchitecture definitions and feature aliases",
   "type": "object",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
fixes #39

I've marked this as draft because I need some input on the `compilers` part for this entry (which I've omitted now)

Detection works as expected on an AWS C7g (`c7x.2xlarge`) instance:

```
$ archspec cpu
graviton3
```

```
$ head -9 /proc/cpuinfo
processor	: 0
BogoMIPS	: 2100.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x1
CPU part	: 0xd40
CPU revision	: 1