### PR TITLE
Remove `umip` feature from icelake

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1099,8 +1099,7 @@
         "avx512cd",
         "avx512vbmi",
         "avx512ifma",
-        "sha",
-        "umip"
+        "sha"
       ],
       "compilers": {
         "gcc": [


### PR DESCRIPTION
This feature is not exposed in virtualized environments, e.g. icelake based AWS EC2 instances.

With the `umip` flag in place there is no way to identify icelake based
instances correctly form within Archspec and the next alternative x86_64_v4 is
too wide for proper optimization.