### PR TITLE
remove x86-64 from intel classic compiler

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -82,13 +82,6 @@
             "flags": "-march={name} -mtune=generic"
           }
         ],
-        "intel": [
-          {
-            "versions": ":",
-            "name": "x86-64",
-            "flags": "-march={name} -mtune=generic"
-          }
-        ],
         "oneapi": [
           {
             "versions": ":",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -85,7 +85,7 @@
         "intel": [
           {
             "versions": ":",
-            "name": "x86-64",
+            "name": "pentium4",
             "flags": "-march={name} -mtune=generic"
           }
         ],

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -82,6 +82,13 @@
             "flags": "-march={name} -mtune=generic"
           }
         ],
+        "intel": [
+          {
+            "versions": ":",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
         "oneapi": [
           {
             "versions": ":",


### PR DESCRIPTION
`x86-64` is nowhere in [the intel classic compiler manual section on the `march` flag](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/code-generation-options/march.html). 

```
/modules/spack-0.18.1/lib/spack/env/intel/icc -fPIC -O2 -D_LARGEFILE64_SOURCE=1  -c -o adler32.o adler32.c
icc: command line warning #10148: option '-march=x86-64' not supported
```

This should probably be fact checked on a system that isn't mine.