### PR TITLE
Remove `pmull` feature from A64FX

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2302,7 +2302,6 @@
         "fp",
         "asimd",
         "evtstrm",
-        "pmull",
         "sha1",
         "sha2",
         "crc32",

--- a/tests/targets/linux-rocky8-a64fx
+++ b/tests/targets/linux-rocky8-a64fx
@@ -1,0 +1,8 @@
+processor       : 0
+BogoMIPS        : 200.00
+Features        : fp asimd evtstrm sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm fcma dcpop sve
+CPU implementer : 0x46
+CPU architecture: 8
+CPU variant     : 0x1
+CPU part        : 0x001
+CPU revision    : 0


### PR DESCRIPTION
With this change in Spack I finally get on Ookami
```console
$ spack arch
linux-rocky8-a64fx
```

This was missed in #44. Should fix #23. Again.