### PR TITLE
neoverse-v1: fix flags for GCC

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2617,7 +2617,15 @@
                   "flags" : "-march=armv8.2-a+crypto+fp16 -mtune=cortex-a72"
               },
               {
-                  "versions": "8.0:9.3",
+                  "versions": "8.0:8.4",
+                  "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
+              },
+              {
+                  "versions": "8.5:8.9",
+                  "flags"  -mcpu=neoverse-v1"
+              },
+              {
+                  "versions": "9.0:9.3",
                   "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
               },
               {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2617,15 +2617,23 @@
                   "flags" : "-march=armv8.2-a+crypto+fp16 -mtune=cortex-a72"
               },
               {
-                  "versions": "8.0:8.9",
+                  "versions": "8.0:9.3",
                   "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
               },
               {
-                  "versions": "9.0:9.9",
+                  "versions": "9.4:9.9",
                   "flags" : "-mcpu=neoverse-v1"
               },
-	            {
-                  "versions": "10.0:",
+              {
+                  "versions": "10.0:10.1",
+                  "flags" : "-march=armv8.2-a+fp16+dotprod+crypto -mtune=cortex-a72"
+              },
+              {
+                  "versions": "10.2",
+                  "flags" : "-mcpu=zeus"
+              },
+              {
+                  "versions": "10.3:",
                   "flags" : "-mcpu=neoverse-v1"
               }
 

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2622,7 +2622,7 @@
               },
               {
                   "versions": "8.5:8.9",
-                  "flags"  -mcpu=neoverse-v1"
+                  "flags" : "-mcpu=neoverse-v1"
               },
               {
                   "versions": "9.0:9.3",


### PR DESCRIPTION
@alalazo @annop-w 

I checked @annop-w spack PR https://github.com/spack/spack/pull/36277 because he wrote he would have to get signoff from his manager to contribute to this repo, so I've checked his changes.

They are mostly correct except that  `-mcpu=neoverse-v1` was already added with `gcc-10.3`:
https://gcc.gnu.org/onlinedocs/gcc-10.3.0/gcc/AArch64-Options.html#AArch64-Options

So the commit message is:

`gcc-10.2` added `-mcpu=zeus` for neoverse-v1 platform
and  `-mcpu=neoverse-v1` was added with `gcc-9.4`, `gcc-10.3` and `gcc-11.0`.

Inspired by https://github.com/spack/spack/pull/36277 by Annop Wongwathanarat 
but updated because for the gcc-10 series, -mcpu=neoverse-v1 started to appear already with gcc-10.3.0:

https://gcc.gnu.org/onlinedocs/gcc-10.3.0/gcc/AArch64-Options.html#AArch64-Options