### PR TITLE
Apple M2: fix microarchitecture optimization flags

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2782,6 +2782,10 @@
           {
             "versions": "13.0:",
             "flags" : "-mcpu=apple-m1"
+          },
+          {
+            "versions": "16.0:",
+            "flags" : "-mcpu=apple-m2"
           }
         ],
         "apple-clang": [

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2790,8 +2790,12 @@
             "flags" : "-march=armv8.5-a"
           },
           {
-            "versions": "13.0:",
-            "flags" : "-mcpu=vortex"
+            "versions": "13.0:14.0.2",
+            "flags" : "-mcpu=apple-m1"
+          },
+          {
+            "versions": "14.0.2:",
+            "flags" : "-mcpu=apple-m2"
           }
         ]
       }


### PR DESCRIPTION
fixes #63 

Modifications:
- [x] Fix flags for Apple M2 when using Apple-Clang
- [x] Update flags for Apple M2 when using LLVM-Clang (see https://github.com/llvm/llvm-project/commit/677da09d0259d7530d32e85cb561bee15f0066e2)