### PR TITLE
add AMD Zen4 architecture flags for GCC 13.1+

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2083,9 +2083,14 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "10.3:",
+            "versions": "10.3:13.0",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
+          },
+          {
+            "versions": "13.1:",
+            "name": "znver4",
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "clang": [


### PR DESCRIPTION
Full znver4 support is present as of the 13.1 release.