### PR TITLE
Add AMD Zen4 Architecture Flags for LLVM 16

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2095,7 +2095,7 @@
         ],
         "clang": [
           {
-            "versions": "12.0:15.0",
+            "versions": "12.0:15.9",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
           },

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2095,11 +2095,16 @@
         ],
         "clang": [
           {
-            "versions": "12.0:",
+            "versions": "12.0:15.0",
             "name": "znver3",
             "flags": "-march={name} -mtune={name} -mavx512f -mavx512dq -mavx512ifma -mavx512cd -mavx512bw -mavx512vl -mavx512vbmi -mavx512vbmi2 -mavx512vnni -mavx512bitalg"
+          },
+          {
+            "versions": "16.0:",
+            "name": "znver4",
+            "flags": "-march={name} -mtune={name}"
           }
-        ],
+	],
         "aocc": [
           {
             "versions": "3.0:3.9",


### PR DESCRIPTION
Complete `znver4` support is present from LLVM 16