### PR TITLE
archspec: oneapi@2022.1: now support x86-64 but old still core2

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -91,6 +91,11 @@
         ],
         "oneapi": [
           {
+            "versions": ":2022",
+            "name": "core2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
             "versions": ":",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic"


### PR DESCRIPTION
Submitted here from https://github.com/spack/spack/pull/38507.