### PR TITLE
Remove erms & avic flags from zen4

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2086,8 +2086,6 @@
         "pku",
         "gfni",
         "flush_l1d",
-        "erms",
-        "avic",
         "avx512f",
         "avx512dq",
         "avx512ifma",


### PR DESCRIPTION
Removing CPU flags to enable compilation inside hypervisors on zen4 processors. These two flags do not represent any compiler options, thus do not influence compatibility of compiled code.

Adding @amd-toolchain-support for review.