### PR TITLE
AMD EPYC Remove unneeded PKU flag

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2080,8 +2080,7 @@
         "popcnt",
         "clwb",
         "vaes",
-        "vpclmulqdq",
-        "pku"
+        "vpclmulqdq"
       ],
       "compilers": {
         "gcc": [
@@ -2169,7 +2168,6 @@
         "clwb",
         "vaes",
         "vpclmulqdq",
-        "pku",
         "gfni",
         "flush_l1d",
         "avx512f",


### PR DESCRIPTION
The `pku` flag is not guaranteed to be present on all systems (virtualization, bios settings).  Removal fixes arch misdetection on various cloud instance types (e.g AWS c6a)