### PR TITLE
Add CPU family/model information as a top level attribute

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3462,5 +3462,31 @@
       "clfsopt": "clflushopt",
       "xsave": "xsavec xsaveopt"
     }
+  },
+  "models": {
+    "description": "Lookup table from CPU family and model number to the corresponding microarchitecture",
+    "x86_64": [
+      {
+        "family": "6",
+        "model": "46",
+        "uarch": "nehalem"
+      },
+      {
+        "family": "6",
+        "model": "30",
+        "uarch": "nehalem"
+      },
+      {
+        "family": "6",
+        "model": "26",
+        "uarch": "nehalem"
+      },
+
+      {
+        "family": "6",
+        "model": "140",
+        "uarch": "icelake"
+      }
+    ]
   }
 }

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -105,6 +105,32 @@
         }
       },
       "additionalProperties": false
+    },
+    "models": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "x86_64": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "family": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "uarch": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
In this PR we introduce a top-level attribute with mappings from CPU family/model numbers to the corresponding microarchitecture names. At the moment this is a prototype to showcase a possible enhancement of the detection algorithm on x86_64 processors.

If the approach seems ok, then we need to add the remaining data points from https://en.wikichip.org/wiki/intel/cpuid and https://en.wikichip.org/wiki/amd/cpuid
