### PR TITLE
Remove `paca`, `pacg`, and `bti` from Neoverse V2

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3066,8 +3066,6 @@
 	  "flagm",
 	  "ssbs",
 	  "sb",
-	  "paca",
-	  "pacg",
 	  "dcpodp",
 	  "sve2",
 	  "sveaes",
@@ -3081,8 +3079,7 @@
 	  "svebf16",
 	  "i8mm",
 	  "bf16",
-	  "dgh",
-	  "bti"
+	  "dgh"
       ],
       "compilers" : {
           "gcc": [

--- a/tests/targets/linux-rhel9-neoverse_v2
+++ b/tests/targets/linux-rhel9-neoverse_v2
@@ -1,0 +1,8 @@
+processor       : 0
+BogoMIPS        : 2000.00
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bf16 dgh
+CPU implementer : 0x41
+CPU architecture: 8
+CPU variant     : 0x0
+CPU part        : 0xd4f
+CPU revision    : 0


### PR DESCRIPTION
These features are not always reported by the operating system.

Fix #83.