### PR TITLE
Remove `paca`, `pacg`, and `bti` from Neoverse V1

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2937,8 +2937,6 @@
           "ilrcpc",
           "flagm",
           "ssbs",
-          "paca",
-          "pacg",
           "dcpodp",
           "svei8mm",
           "svebf16",

--- a/tests/targets/linux-rhel8-neoverse_v1
+++ b/tests/targets/linux-rhel8-neoverse_v1
@@ -1,0 +1,8 @@
+processor	: 0
+BogoMIPS	: 2100.00
+Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs dcpodp svei8mm svebf16 i8mm bf16 dgh rng
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x1
+CPU part	: 0xd40
+CPU revision	: 1


### PR DESCRIPTION
These features are not always reported by the operating system, and they don't cause SIGILL when not supported by the platform.