### PR TITLE
Add GCC 12.3 neoverse-v2 support

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3106,11 +3106,11 @@
                   "flags" : "-march=armv8.5-a+sve+sve2+i8mm+bf16 -mtune=cortex-a77"
               },
               {
-                  "versions": "12.0:12.99",
+                  "versions": "12.0:12.2.99",
                   "flags" : "-march=armv9-a+i8mm+bf16 -mtune=cortex-a710"
               },
-	      {
-                  "versions": "13.0:",
+              {
+                  "versions": "12.3:",
                   "flags" : "-mcpu=neoverse-v2"
               }
           ],


### PR DESCRIPTION
See neoverse-v2 references in [gcc 12.3 changelog](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/ChangeLog;hb=refs/tags/releases/gcc-12.3.0) (I could not find references in [release note](https://gcc.gnu.org/gcc-12/changes.html)).

And [nvidia recommends gcc 12.3+](https://nvidia.github.io/grace-cpu-benchmarking-guide/developer/languages/c-c++.html#recommended-compiler-flags) with `-mcpu=neoverse-v2`.

I smoke-tested it on rhel9 with custom build gcc 12.3 and custom build binutils 2.42.