### PR TITLE
Add Arm-data as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "arm_data"]
+	path = arm_data
+	url = https://github.com/ARM-software/data


### PR DESCRIPTION
This patch adds the repo https://github.com/ARM-software/data for identification of architectures to the json submodule.