### PR TITLE
Adding optional CPUID field in microarchitecture schema and in json file for Arm architectures

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2820,7 +2820,8 @@
                   "flags" : "-mcpu=cortex-a72"
               }
           ]
-      }
+      },
+      "cpuid": "0x41d08"
     },
     "neoverse_n1": {
       "from": ["cortex_a72", "armv8.2a"],
@@ -2906,7 +2907,8 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpuid": "0x41d0c"
     },
     "neoverse_v1": {
       "from": ["neoverse_n1", "armv8.4a"],
@@ -3032,7 +3034,8 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpuid": "0x41d40"
     },
     "neoverse_v2": {
       "from": ["neoverse_n1", "armv9.0a"],
@@ -3149,7 +3152,8 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpuid": "0x41d4f"
     },
     "m1": {
       "from": ["armv8.4a"],

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2821,7 +2821,7 @@
               }
           ]
       },
-      "cpuid": "0x41d08"
+      "cpupart": "0xd08"
     },
     "neoverse_n1": {
       "from": ["cortex_a72", "armv8.2a"],
@@ -2908,7 +2908,7 @@
               }
           ]
       },
-      "cpuid": "0x41d0c"
+      "cpupart": "0xd0c"
     },
     "neoverse_v1": {
       "from": ["neoverse_n1", "armv8.4a"],
@@ -3035,7 +3035,7 @@
               }
           ]
       },
-      "cpuid": "0x41d40"
+      "cpupart": "0xd40"
     },
     "neoverse_v2": {
       "from": ["neoverse_n1", "armv9.0a"],
@@ -3153,7 +3153,7 @@
               }
           ]
       },
-      "cpuid": "0x41d4f"
+      "cpupart": "0xd4f"
     },
     "m1": {
       "from": ["armv8.4a"],

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -52,6 +52,9 @@
                   }
                 }
               }
+            },
+            "cpuid": {
+              "type": "string"
             }
           },
           "required": [

--- a/cpu/microarchitectures_schema.json
+++ b/cpu/microarchitectures_schema.json
@@ -53,7 +53,7 @@
                 }
               }
             },
-            "cpuid": {
+            "cpupart": {
               "type": "string"
             }
           },


### PR DESCRIPTION
As part of https://github.com/archspec/archspec/pull/168 on the archspec repo, it was decided to add, where it made sense for ARM cores a new field, called `cpuid` rather than adding a new submodule just for that.

These changes aim at:

 - adding the optional field in the microarchitecture_schema file 
 - introducing the field "cpuid" in the ARM microarchitectures 

This field will be used in the cpu/detect.py file in the archspec repo, for which a separate PR will be opened. 

CC: @dslarm