### PR TITLE
Remove `PDCM` from the sapphirerapids list

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1482,7 +1482,6 @@
         "cldemote",
         "movdir64b",
         "movdiri",
-        "pdcm",
         "serialize",
         "waitpkg"
       ],


### PR DESCRIPTION
`PDCM` is not a feature currently used by compilers, see for instance https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.

For GCP VMs, only ones that have vPMU [enabled](https://cloud.google.com/compute/docs/manage-pmu-in-vms) would have `PDCM` exposed in the guest. Including `PDCM` would therefore cause these non-vPMU-enabled VMs to be identified as icelake instead.