### PR TITLE
Remove ssbs from neoverse* CPUs

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2844,8 +2844,7 @@
           "asimdrdm",
           "lrcpc",
           "dcpop",
-          "asimddp",
-          "ssbs"
+          "asimddp"
       ],
       "compilers" : {
           "gcc": [
@@ -2942,7 +2941,6 @@
           "uscat",
           "ilrcpc",
           "flagm",
-          "ssbs",
           "dcpodp",
           "svei8mm",
           "svebf16",
@@ -3010,7 +3008,7 @@
               },
               {
                   "versions": "11:",
-                  "flags" : "-march=armv8.4-a+sve+ssbs+fp16+bf16+crypto+i8mm+rng"
+                  "flags" : "-march=armv8.4-a+sve+fp16+bf16+crypto+i8mm+rng"
               },
               {
                   "versions": "12:",
@@ -3066,7 +3064,6 @@
 	  "uscat",
 	  "ilrcpc",
 	  "flagm",
-	  "ssbs",
 	  "sb",
 	  "dcpodp",
 	  "sve2",
@@ -3179,7 +3176,6 @@
 	  "uscat",
 	  "ilrcpc",
 	  "flagm",
-	  "ssbs",
 	  "sb",
 	  "dcpodp",
 	  "sve2",


### PR DESCRIPTION
ARM published an
[erratum](file:///Users/stesachs/Downloads/arm_cortex_x4_mp161_software_developer_errata_notice_v8_0.pdf) which lead to a kernel
[workaround](https://lore.kernel.org/all/ed8d11e9-620a-44a0-bf72-23885175fc98@arm.com/T/#m933fd14766ff45f73428a8515fd59b4b8aecfe80) not showing the `ssbs` CPU flag on these CPUs any more.