### PR TITLE
Remove `cppc` from the zen5 feature list

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2284,7 +2284,6 @@
         "clflushopt",
         "clwb",
         "clzero",
-        "cppc",
         "cx16",
         "f16c",
         "flush_l1d",


### PR DESCRIPTION
Motivations for taking `cppc` out:

* There's no upstream support in KVM for this AMD feature, so this won't be trivial to support for KVM-based virtualization. Plus AFAIK this feature isn't used in Linux yet.

* This does not seem to be something a compiler would use. For instance this is not included in GCC's znver5 list: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.

* There are other existing features that can tell zen5 apart from previous zen generations, for instance `avx_vnni` and `movdiri`, so the removal won't impact correct identification.