### PR TITLE
Add Intel Granite Rapids support

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1633,6 +1633,94 @@
         ]
       }
     },
+    "graniterapids": {
+      "from": [
+        "sapphirerapids"
+      ],
+      "vendor": "GenuineIntel",
+      "features": [
+        "aes",
+        "amx_bf16",
+        "amx_int8",
+        "amx_tile",
+        "avx",
+        "avx2",
+        "avx512_bf16",
+        "avx512_bitalg",
+        "avx512_fp16",
+        "avx512_vbmi2",
+        "avx512_vnni",
+        "avx512_vpopcntdq",
+        "avx512bw",
+        "avx512cd",
+        "avx512dq",
+        "avx512f",
+        "avx512ifma",
+        "avx512vbmi",
+        "avx512vl",
+        "avx_vnni",
+        "bmi1",
+        "bmi2",
+        "cldemote",
+        "clflushopt",
+        "clwb",
+        "cx16",
+        "enqcmd",
+        "f16c",
+        "fma",
+        "fsgsbase",
+        "fxsr",
+        "gfni",
+        "mmx",
+        "movbe",
+        "movdir64b",
+        "movdiri",
+        "pconfig",
+        "pku",
+        "popcnt",
+        "rdpid",
+        "rdrand",
+        "rdseed",
+        "serialize",
+        "sse",
+        "sse2",
+        "sse4_1",
+        "sse4_2",
+        "ssse3",
+        "tsxldtrk",
+        "waitpkg",
+        "wbnoinvd",
+        "xsave",
+        "xsavec",
+        "xsaves"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "13.1:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "16.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "oneapi": [
+          {
+            "versions": "2023.2:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "dpcpp": [
+          {
+            "versions": "2023.2:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+      }
+    },
     "k10": {
       "from": [
         "x86_64"

--- a/tests/targets/linux-rhel9-graniterapids
+++ b/tests/targets/linux-rhel9-graniterapids
@@ -1,0 +1,27 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 173
+model name      : Intel(R) Xeon(R) 6972P
+stepping        : 1
+microcode       : 0x1000380
+cpu MHz         : 2400.000
+cache size      : 491520 KB
+physical id     : 0
+siblings        : 96
+core id         : 0
+cpu cores       : 96
+apicid          : 0
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 36
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cat_l2 cdp_l3 intel_ppin cdp_l2 ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect avx_vnni avx512_bf16 wbnoinvd dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req hfi vnmi avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la57 rdpid bus_lock_detect cldemote movdiri movdir64b enqcmd fsrm md_clear serialize tsxldtrk pconfig arch_lbr ibt amx_bf16 avx512_fp16 amx_tile amx_int8 flush_l1d arch_capabilities
+vmx flags       : vnmi preemption_timer posted_intr invvpid ept_x_only ept_ad ept_1gb ept_5level flexpriority apicv tsc_offset vtpr mtf vapic ept vpid unrestricted_guest vapic_reg vid ple shadow_vmcs pml ept_violation_ve ept_mode_based_exec tsc_scaling usr_wait_pause notify_vm_exiting ipi_virt
+bugs            : spectre_v1 spectre_v2 spec_store_bypass swapgs bhi
+bogomips        : 4800.00
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 52 bits physical, 57 bits virtual
+power management:


### PR DESCRIPTION
This adds support for Intel Granite Rapids.  The changes are:

* Description of the Granite Rapids to `microsarchitectures.json`
* Addition of test output from my site's `/proc/cpuinfo` on our RHEL9 Granite Rapids machine.

Fixes #137 