### PR TITLE
Removed ibrs_enhanced

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -2431,7 +2431,6 @@
         "fma",
         "fsgsbase",
         "gfni",
-        "ibrs_enhanced",
         "mmx",
         "movbe",
         "movdir64b",


### PR DESCRIPTION
Our AMD EPYC 9655 doesn't have this flag, so archspec identifies it as a zen4.