### PR TITLE
m4: add gcc support

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3600,6 +3600,10 @@
           {
             "versions": "8.0:",
             "flags": "-march=armv8.4-a -mtune=generic"
+          },
+          {
+            "versions": "15.1:",
+            "flags": "-mcpu=apple-m1"
           }
         ],
         "clang": [
@@ -3674,6 +3678,10 @@
           {
             "versions": "10.1:",
             "flags": "-march=armv8.6-a -mtune=generic"
+          },
+          {
+            "versions": "15.1:",
+            "flags": "-mcpu=apple-m2"
           }
         ],
         "clang": [
@@ -3756,6 +3764,10 @@
           {
             "versions": "10.1:",
             "flags": "-march=armv8.6-a -mtune=generic"
+          },
+          {
+            "versions": "15.1:",
+            "flags": "-mcpu=apple-m3"
           }
         ],
         "clang": [

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3842,8 +3842,12 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "8.0:",
-            "flags": "-march=armv8.5-a"
+            "versions": "10.1:",
+            "flags": "-march=armv8.6-a -mtune=generic"
+          },
+          {
+            "versions": "14.1:",
+            "flags": "-march=armv8.6-a+sme2 -mtune=generic"
           }
         ],
         "clang": [

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3840,6 +3840,12 @@
         "sme2"
       ],
       "compilers": {
+        "gcc": [
+          {
+            "versions": "8.0:"
+            "flags": "-march=armv8.5-a"
+          },
+        ],
         "clang": [
           {
             "versions": "9.0:12.0",

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3675,7 +3675,6 @@
             "versions": "10.1:",
             "flags": "-march=armv8.6-a -mtune=generic"
           }
-
         ],
         "clang": [
           {

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3672,9 +3672,10 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "8.0:",
-            "flags": "-march=armv8.5-a -mtune=generic"
+            "versions": "10.1:",
+            "flags": "-march=armv8.6-a -mtune=generic"
           }
+
         ],
         "clang": [
           {
@@ -3754,8 +3755,8 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "8.0:",
-            "flags": "-march=armv8.5-a -mtune=generic"
+            "versions": "10.1:",
+            "flags": "-march=armv8.6-a -mtune=generic"
           }
         ],
         "clang": [
@@ -3841,10 +3842,6 @@
       ],
       "compilers": {
         "gcc": [
-          {
-            "versions": "10.1:",
-            "flags": "-march=armv8.6-a -mtune=generic"
-          },
           {
             "versions": "14.1:",
             "flags": "-march=armv8.6-a+sme2 -mtune=generic"

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3855,7 +3855,7 @@
         "gcc": [
           {
             "versions": "14.1:",
-            "flags": "-march=armv8.6-a+sme2 -mtune=generic"
+            "flags": "-march=armv9.2-a+sme2 -fno-tree-vectorize -fno-tree-slp-vectorize -mtune=generic"
           }
         ],
         "clang": [

--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -3842,9 +3842,9 @@
       "compilers": {
         "gcc": [
           {
-            "versions": "8.0:"
+            "versions": "8.0:",
             "flags": "-march=armv8.5-a"
-          },
+          }
         ],
         "clang": [
           {


### PR DESCRIPTION
For gcc
m1 --> armv8.4-a (available from 8.0)
m2 --> armv8.6-a (available from 10.1)
m3 == m2
m4 --> armv8.6-a+sme2