### PR TITLE
Add `arrowlake-s` and ancestors to JSON

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -1633,6 +1633,197 @@
         ]
       }
     },
+    "alderlake": {
+      "from": [
+        "skylake"
+      ],
+      "vendor": "GenuineIntel",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "abm",
+        "lahf_lm",
+        "xsave",
+        "cx16",
+        "aes",
+        "pclmulqdq",
+        "avx",
+        "rdrand",
+        "f16c",
+        "movbe",
+        "fma",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "rdseed",
+        "adx",
+        "clflushopt",
+        "xsavec",
+        "xsaveopt",
+        "avx_vnni",
+        "sha_ni",
+        "clwb",
+        "rdpid",
+        "gfni",
+        "vaes",
+        "vpclmulqdq",
+        "movdiri",
+        "movdir64b",
+        "serialize",
+        "waitpkg"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+      }
+    },
+    "arrowlake": {
+      "from": [
+        "alderlake"
+      ],
+      "vendor": "GenuineIntel",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "abm",
+        "lahf_lm",
+        "xsave",
+        "cx16",
+        "aes",
+        "pclmulqdq",
+        "avx",
+        "rdrand",
+        "f16c",
+        "movbe",
+        "fma",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "rdseed",
+        "adx",
+        "clflushopt",
+        "xsavec",
+        "xsaveopt",
+        "avx_vnni",
+        "sha_ni",
+        "clwb",
+        "rdpid",
+        "gfni",
+        "vaes",
+        "vpclmulqdq",
+        "movdiri",
+        "movdir64b",
+        "serialize",
+        "waitpkg",
+        "avx_ifma",
+        "avx_ne_convert",
+        "avx_vnni_int8",
+        "cmpccxadd"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "14.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "18.0:",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+      }
+    },
+    "arrowlake_s": {
+      "from": [
+        "arrowlake"
+      ],
+      "vendor": "GenuineIntel",
+      "features": [
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "abm",
+        "lahf_lm",
+        "xsave",
+        "cx16",
+        "aes",
+        "pclmulqdq",
+        "avx",
+        "rdrand",
+        "f16c",
+        "movbe",
+        "fma",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "rdseed",
+        "adx",
+        "clflushopt",
+        "xsavec",
+        "xsaveopt",
+        "avx_vnni",
+        "sha_ni",
+        "clwb",
+        "rdpid",
+        "gfni",
+        "vaes",
+        "vpclmulqdq",
+        "movdiri",
+        "movdir64b",
+        "serialize",
+        "waitpkg",
+        "avx_ifma",
+        "avx_ne_convert",
+        "avx_vnni_int8",
+        "cmpccxadd",
+        "avx_vnni_int16",
+        "sha512",
+        "sm3",
+        "sm4"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "14.0:",
+            "name": "arrowlake-s",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "18.0:",
+            "name": "arrowlake-s",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ]
+      }
+    },
     "k10": {
       "from": [
         "x86_64"

--- a/tests/targets/linux-ubuntu24.04-alderlake
+++ b/tests/targets/linux-ubuntu24.04-alderlake
@@ -1,0 +1,27 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 198
+model name      : Intel(R) Core(TM) Ultra 9 285
+stepping        : 2
+microcode       : 0x11f
+cpu MHz         : 800.000
+cache size      : 36864 KB
+physical id     : 0
+siblings        : 24
+core id         : 0
+cpu cores       : 24
+apicid          : 0
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 35
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdt_a rdseed adx smap clflushopt clwb intel_pt sha_ni xsaveopt xsavec xgetbv1 xsaves split_lock_detect user_shstk avx_vnni lam wbnoinvd dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req hfi vnmi umip pku ospke waitpkg gfni vaes vpclmulqdq rdpid bus_lock_detect movdiri movdir64b fsrm md_clear serialize pconfig arch_lbr ibt flush_l1d arch_capabilities
+vmx flags       : vnmi preemption_timer posted_intr invvpid ept_x_only ept_ad ept_1gb flexpriority apicv tsc_offset vtpr mtf vapic ept vpid unrestricted_guest vapic_reg vid ple shadow_vmcs pml ept_violation_ve ept_mode_based_exec tsc_scaling usr_wait_pause notify_vm_exiting ipi_virt
+bugs            : spectre_v1 spectre_v2 spec_store_bypass swapgs bhi spectre_v2_user vmscape
+bogomips        : 4992.00
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 46 bits physical, 48 bits virtual
+power management:

--- a/tests/targets/linux-ubuntu26.04-arrowlake_s
+++ b/tests/targets/linux-ubuntu26.04-arrowlake_s
@@ -1,0 +1,27 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 198
+model name      : Intel(R) Core(TM) Ultra 9 285
+stepping        : 2
+microcode       : 0x11f
+cpu MHz         : 800.000
+cache size      : 36864 KB
+physical id     : 0
+siblings        : 24
+core id         : 0
+cpu cores       : 24
+apicid          : 0
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 35
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdt_a rdseed adx smap clflushopt clwb intel_pt sha_ni xsaveopt xsavec xgetbv1 xsaves split_lock_detect user_shstk avx_vnni avx_vnni_int8 avx_vnni_int16 avx_ne_convert avx_ifma cmpccxadd sha512 sm3 sm4 lam wbnoinvd dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req hfi vnmi umip pku ospke waitpkg gfni vaes vpclmulqdq rdpid bus_lock_detect movdiri movdir64b fsrm md_clear serialize pconfig arch_lbr ibt flush_l1d arch_capabilities
+vmx flags       : vnmi preemption_timer posted_intr invvpid ept_x_only ept_ad ept_1gb flexpriority apicv tsc_offset vtpr mtf vapic ept vpid unrestricted_guest vapic_reg vid ple shadow_vmcs pml ept_violation_ve ept_mode_based_exec tsc_scaling usr_wait_pause notify_vm_exiting ipi_virt
+bugs            : spectre_v1 spectre_v2 spec_store_bypass swapgs bhi spectre_v2_user vmscape
+bogomips        : 4992.00
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 46 bits physical, 48 bits virtual
+power management:


### PR DESCRIPTION
This commit adds 3 new microarchitectures to the JSON database:
```
alderlake -> arrowlake -> arrowlake-s
```
Compiler knowledge for them is currently limited to GCC and Clang.

The ubuntu 26.04 tests is "synthetic" and constructed based on the alderlake test (kernel is too old to expose all the features).